### PR TITLE
Fix discrepancy with readme.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ paypal_url:
 flattr_button:
 
 # Build settings
-markdown:     redcarpet
+markdown:     kramdown
 redcarpet:
   extensions: ['smart', 'tables', 'with_toc_data']
 permalink:    pretty


### PR DESCRIPTION
README.md shows `kramdown` yet we used `redcarpet` in `_config.yml`.
Decided on kramdown because of https://help.github.com/articles/migrating-your-pages-site-from-maruku/